### PR TITLE
Record - Catch Exception When Key is Missing

### DIFF
--- a/rets/client/record.py
+++ b/rets/client/record.py
@@ -8,8 +8,12 @@ class Record:
     def __init__(self, resource_class, data: dict):
         self.resource = resource_class.resource
         self.resource_class = resource_class
-        self.resource_key = str(data[resource_class.resource.key_field])
         self.data = data
+        
+        try:
+            self.resource_key = str(data[resource_class.resource.key_field])
+        except KeyError:
+            self.resource_key = None
 
     def get_objects(self, name: str, **kwargs) -> Sequence[Object]:
         resource_object = self.resource.get_object_type(name)


### PR DESCRIPTION
This part of code was removed from the source of this fork, [here](https://github.com/homelight/rets/commit/09fbabfe7827f86a266f73ad7830c9bb68880c11).

The MLSPIN feed has a key field that doesn't appear in the results, so the line of code trying to get the key fails. I'm not gonna remove this part of the class as it was in the fork source, I'll just catch the exception to make sure we don't break anything.

[sc-77735]